### PR TITLE
replace CMSObject with Registry

### DIFF
--- a/src/administrator/components/com_jed/layouts/ticket/linked_extension.php
+++ b/src/administrator/components/com_jed/layouts/ticket/linked_extension.php
@@ -63,10 +63,10 @@ echo HTMLHelper::_(
     </div>
 <?php echo HTMLHelper::_('uitab.endTab');
 echo HTMLHelper::_(
-	'uitab.addTab',
-	'viewExtensionDescriptionTab',
-	'general',
-	Text::_('COM_JED_EXTENSIONS_DESCRIPTION_TAB')
+    'uitab.addTab',
+    'viewExtensionDescriptionTab',
+    'general',
+    Text::_('COM_JED_EXTENSIONS_DESCRIPTION_TAB')
 ); ?>
 <div class="row-fluid form-horizontal-desktop">
     <div class="span9">

--- a/src/administrator/components/com_jed/layouts/ticket/linked_extension.php
+++ b/src/administrator/components/com_jed/layouts/ticket/linked_extension.php
@@ -28,7 +28,7 @@ $fieldhiddenoptions = ['hidden' => true];
 
 $extension_form = $displayData->extension_form;
 $title          = $extension_form->getField('title') ? 'title' : ($extension_form->getField('name') ? 'name' : '');
-JedHelper::lockFormFields($extension_form, array(''));
+JedHelper::lockFormFields($extension_form, ['']);
 ?>
     <div class="row title-alias form-vertical mb-3">
         <div class="col-12 col-md-6">
@@ -89,35 +89,35 @@ echo HTMLHelper::_('uitab.addTab', 'viewExtensionTab', 'viewextension', Text::_(
 
 JedHelper::lockFormFields($extension_form, array(''));
 
-        //       echo $extension_form->renderField('title',null,null);
-            //   echo $extension_form->renderField('alias',null,null);
-                 echo $extension_form->renderField('published',null,null);
-                 echo $extension_form->renderField('created_by',null,null);
-                 echo $extension_form->renderField('modified_by',null,null);
-                 echo $extension_form->renderField('created_on',null,null);
-                 echo $extension_form->renderField('modified_on',null,null);
-            //   echo $extension_form->renderField('joomla_versions',null,null);
-                 echo $extension_form->renderField('popular',null,null);
-                 echo $extension_form->renderField('requires_registration',null,null);
-                 echo $extension_form->renderField('gpl_license_type',null,null);
-                 echo $extension_form->renderField('jed_internal_note',null,null);
-                 echo $extension_form->renderField('can_update',null,null);
-                 echo $extension_form->renderField('video',null,null);
-                 echo $extension_form->renderField('version',null,null);
-                 echo $extension_form->renderField('uses_updater',null,null);
-        //       echo $extension_form->renderField('includes',null,null);
-                 echo $extension_form->renderField('approved',null,null);
-                 echo $extension_form->renderField('approved_time',null,null);
-                 echo $extension_form->renderField('second_contact_email',null,null);
-                 echo $extension_form->renderField('jed_checked',null,null);
-                 echo $extension_form->renderField('uses_third_party',null,null);
-                 echo $extension_form->renderField('primary_category_id',null,null);
-                 echo $extension_form->renderField('logo',null,null);
-                 echo $extension_form->renderField('approved_notes',null,null);
-                 echo $extension_form->renderField('approved_reason',null,null);
-                 echo $extension_form->renderField('published_notes',null,null);
-                 echo $extension_form->renderField('published_reason',null,null);
-                 echo $extension_form->renderField('state',null,null);
+// echo $extension_form->renderField('title',null,null);
+// echo $extension_form->renderField('alias',null,null);
+echo $extension_form->renderField('published',null,null);
+echo $extension_form->renderField('created_by',null,null);
+echo $extension_form->renderField('modified_by',null,null);
+echo $extension_form->renderField('created_on',null,null);
+echo $extension_form->renderField('modified_on',null,null);
+// echo $extension_form->renderField('joomla_versions',null,null);
+echo $extension_form->renderField('popular',null,null);
+echo $extension_form->renderField('requires_registration',null,null);
+echo $extension_form->renderField('gpl_license_type',null,null);
+echo $extension_form->renderField('jed_internal_note',null,null);
+echo $extension_form->renderField('can_update',null,null);
+echo $extension_form->renderField('video',null,null);
+echo $extension_form->renderField('version',null,null);
+echo $extension_form->renderField('uses_updater',null,null);
+// echo $extension_form->renderField('includes',null,null);
+echo $extension_form->renderField('approved',null,null);
+echo $extension_form->renderField('approved_time',null,null);
+echo $extension_form->renderField('second_contact_email',null,null);
+echo $extension_form->renderField('jed_checked',null,null);
+echo $extension_form->renderField('uses_third_party',null,null);
+echo $extension_form->renderField('primary_category_id',null,null);
+echo $extension_form->renderField('logo',null,null);
+echo $extension_form->renderField('approved_notes',null,null);
+echo $extension_form->renderField('approved_reason',null,null);
+echo $extension_form->renderField('published_notes',null,null);
+echo $extension_form->renderField('published_reason',null,null);
+echo $extension_form->renderField('state',null,null);
 echo HTMLHelper::_('uitab.endTab'); */
 
 $varied_form = $displayData->varied_form;

--- a/src/administrator/components/com_jed/src/Model/ExtensionModel.php
+++ b/src/administrator/components/com_jed/src/Model/ExtensionModel.php
@@ -114,7 +114,7 @@ class ExtensionModel extends AdminModel
             $this->getDatabase()->setQuery($query);
             $item->images = $this->getDatabase()->loadObjectList();
 
-            $item->includes = json_decode($item->includes);
+            $item->includes        = json_decode($item->includes);
             $item->joomla_versions = json_decode($item->joomla_versions);
         }
 

--- a/src/administrator/components/com_jed/src/Model/JedticketModel.php
+++ b/src/administrator/components/com_jed/src/Model/JedticketModel.php
@@ -240,7 +240,7 @@ class JedticketModel extends AdminModel
         $query->select('a.*'); // `b`.`title`, `b`.`alias`');
 
         $query->from($db->quoteName('#__jed_extensions', 'a'));
-    //    $query->join("inner", "`#__jed_extension_varied_data` as b", "`b`.`extension_id` = `a`.`id`");
+        // $query->join("inner", "`#__jed_extension_varied_data` as b", "`b`.`extension_id` = `a`.`id`");
 
         $query->where('a.created_by = ' . $ticket_creator);
 

--- a/src/administrator/components/com_jed/src/View/Copyjed3data/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Copyjed3data/HtmlView.php
@@ -20,7 +20,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Registry\Registry;
@@ -45,10 +44,10 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    Registry
      * @since  4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Component Parameters

--- a/src/administrator/components/com_jed/src/View/Extension/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extension/HtmlView.php
@@ -22,8 +22,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Registry\Registry;
 
 /**
  * View class for a single Extension.
@@ -33,7 +33,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
 class HtmlView extends BaseHtmlView
 {
     public mixed $extensionvarieddata;
-    protected CMSObject $state;
+    protected Registry $state;
     protected mixed $item;
     protected Form $form;
     protected mixed $forms;

--- a/src/administrator/components/com_jed/src/View/Extensionimage/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensionimage/HtmlView.php
@@ -19,7 +19,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -29,7 +29,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  */
 class HtmlView extends BaseHtmlView
 {
-    protected CMSObject $state;
+    protected Registry $state;
 
     protected mixed $item;
 

--- a/src/administrator/components/com_jed/src/View/Extensionimages/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensionimages/HtmlView.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
     public array $activeFilters = [];
     protected array $items;
     protected Pagination $pagination;
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Extensions/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensions/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -41,11 +41,11 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  Registry
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Display the view

--- a/src/administrator/components/com_jed/src/View/Extensionscore/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensionscore/HtmlView.php
@@ -19,7 +19,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -29,7 +29,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  */
 class HtmlView extends BaseHtmlView
 {
-    protected CMSObject $state;
+    protected Registry $state;
 
     protected mixed $item;
 

--- a/src/administrator/components/com_jed/src/View/Extensionscores/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensionscores/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -37,7 +37,7 @@ class HtmlView extends BaseHtmlView
     public array $activeFilters = [];
     protected array $items;
     protected Pagination $pagination;
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Extensionsupplyoption/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensionsupplyoption/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -33,11 +33,11 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  Registry
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Extensionsupplyoptions/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Extensionsupplyoptions/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -41,11 +41,11 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  Registry
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Jedticket/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Jedticket/HtmlView.php
@@ -252,7 +252,8 @@ class HtmlView extends BaseHtmlView
             $this->linked_extension_data->extension_form = $this->linked_extension_form;
 
 
-        /*    $extensionvarieddatum                   = new ExtensionvarieddatumModel();
+            /*
+            $extensionvarieddatum                   = new ExtensionvarieddatumModel();
             $this->linked_extension_varieddata      = $this->linked_extension_data->varied_data[$this->linked_item_data[0]->supply_type];
             $this->linked_extension_varieddata_form = $extensionvarieddatum->getForm(
                 $this->linked_extension_varieddata,
@@ -261,7 +262,8 @@ class HtmlView extends BaseHtmlView
             );
 
             $this->linked_extension_varieddata_form->bind($this->linked_extension_varieddata);
-            $this->linked_extension_data->varied_form = $this->linked_extension_varieddata_form;*/
+            $this->linked_extension_data->varied_form = $this->linked_extension_varieddata_form;
+            */
         }
         if ($this->linked_item_type === 4) { // VEL Report
             $this->linked_item_Model = new VelreportModel();

--- a/src/administrator/components/com_jed/src/View/Jedticket/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Jedticket/HtmlView.php
@@ -28,7 +28,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  */
 class HtmlView extends BaseHtmlView
 {
-    protected CMSObject $state;
+    protected Registry $state;
     protected mixed $item;
     protected mixed $form;
 

--- a/src/administrator/components/com_jed/src/View/Jedtickets/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Jedtickets/HtmlView.php
@@ -22,11 +22,11 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
+use Joomla\Registry\Registry;
 
 /**
  * View class for a list of JED Tickets.
@@ -43,11 +43,11 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  Registry
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Messagetemplate/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Messagetemplate/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Messagetemplates/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Messagetemplates/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -73,14 +73,7 @@ class HtmlView extends BaseHtmlView
      * @var    Registry
      * @since  4.0.0
      */
-    /**
-     * The model state
-     *
-     * @var  object
-     *
-     * @since 4.0.0
-     */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Review/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Review/HtmlView.php
@@ -19,7 +19,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -29,7 +29,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  */
 class HtmlView extends BaseHtmlView
 {
-    protected CMSObject $state;
+    protected Registry $state;
     protected mixed $item;
     protected mixed $form;
 

--- a/src/administrator/components/com_jed/src/View/Reviewcomment/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Reviewcomment/HtmlView.php
@@ -18,7 +18,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -28,7 +28,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  */
 class HtmlView extends BaseHtmlView
 {
-    protected CMSObject $state;
+    protected Registry $state;
 
     protected mixed $item;
 

--- a/src/administrator/components/com_jed/src/View/Reviews/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Reviews/HtmlView.php
@@ -18,7 +18,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
 
     protected Pagination $pagination;
 
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Display the view

--- a/src/administrator/components/com_jed/src/View/Reviewscomments/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Reviewscomments/HtmlView.php
@@ -18,7 +18,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
 
     protected Pagination $pagination;
 
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Display the view

--- a/src/administrator/components/com_jed/src/View/Setupdemo/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Setupdemo/HtmlView.php
@@ -17,10 +17,9 @@ use Exception;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Registry\Registry;
 use SimpleXMLElement;
 
 /**
@@ -40,10 +39,10 @@ class HtmlView extends BaseHtmlView
     /**
          * The model state
          *
-         * @var    CMSObject
+         * @var    Registry
          * @since  4.0.0
          */
-    protected CMSObject $state;
+    protected Registry $state;
     /**
          * Component Parameters
          *

--- a/src/administrator/components/com_jed/src/View/Ticketallocatedgroup/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketallocatedgroup/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Ticketallocatedgroups/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketallocatedgroups/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -72,14 +72,7 @@ class HtmlView extends BaseHtmlView
      * @var    Registry
      * @since  4.0.0
      */
-    /**
-     * The model state
-     *
-     * @var  object
-     *
-     * @since 4.0.0
-     */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Ticketcategories/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketcategories/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Ticketcategory/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketcategory/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Ticketinternalnote/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketinternalnote/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Ticketinternalnotes/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketinternalnotes/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Ticketlinkeditemtype/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketlinkeditemtype/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Ticketlinkeditemtypes/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketlinkeditemtypes/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Ticketmessage/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketmessage/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Ticketmessages/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Ticketmessages/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Velabandonedreport/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Velabandonedreport/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Velabandonedreports/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Velabandonedreports/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Veldeveloperupdate/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Veldeveloperupdate/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Veldeveloperupdates/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Veldeveloperupdates/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Velreport/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Velreport/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Velreports/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Velreports/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/src/View/Velvulnerableitem/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Velvulnerableitem/HtmlView.php
@@ -21,7 +21,7 @@ use Jed\Component\Jed\Administrator\Helper\JedHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * The item object

--- a/src/administrator/components/com_jed/src/View/Velvulnerableitems/HtmlView.php
+++ b/src/administrator/components/com_jed/src/View/Velvulnerableitems/HtmlView.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\Helpers\Sidebar;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
+use Joomla\Registry\Registry;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since 4.0.0
      */
-    protected CMSObject $state;
+    protected Registry $state;
 
     /**
      * Add the page title and toolbar.

--- a/src/administrator/components/com_jed/tmpl/jedticket/edit.php
+++ b/src/administrator/components/com_jed/tmpl/jedticket/edit.php
@@ -251,7 +251,7 @@ $userFactory = $container->get('user.factory');
         echo HTMLHelper::_('uitab.endTab');
     }
     if ($add_extension_tab == true) {
-        echo HTMLHelper::_('uitab.addTab', 'myTab', 'LinkedExtension', 'Linked Extension ('.$this->linked_extension_data->type.')');
+        echo HTMLHelper::_('uitab.addTab', 'myTab', 'LinkedExtension', 'Linked Extension (' . $this->linked_extension_data->type . ')');
 
         echo LayoutHelper::render('ticket.linked_extension', $this->linked_extension_data);
 

--- a/src/components/com_jed/src/Model/CategoriesModel.php
+++ b/src/components/com_jed/src/Model/CategoriesModel.php
@@ -88,7 +88,7 @@ class CategoriesModel extends ListModel
         $query = $db->getQuery(true);
 
         $recursive  = false;
-        $options = ['countItems' => 1];
+        $options    = ['countItems' => 1];
         $categories = Categories::getInstance('Jed', $options);
 
         $this->_parent = $categories->get($this->getState('filter.parentId', 'root'));
@@ -144,7 +144,7 @@ class CategoriesModel extends ListModel
         $this->_items = $list;
 
         return $list;**/
-    return $this->_parent->getChildren();
+        return $this->_parent->getChildren();
     }
 
     /**
@@ -172,8 +172,6 @@ class CategoriesModel extends ListModel
      */
     public function getTotal(): int
     {
-
-
         if (empty($this->_total)) {
             $this->_total = count($this->_items());
         }

--- a/src/components/com_jed/src/Model/CategoryModel.php
+++ b/src/components/com_jed/src/Model/CategoryModel.php
@@ -205,9 +205,7 @@ class CategoryModel extends ListModel
 
         // Set limit for query. If list, use parameter. If blog, add blog parameters for limit.
         if (($app->getInput()->get('layout') === 'blog') || $params->get('layout_type') === 'blog') {
-            $limit = $params->get('num_leading_articles') + $params->get('num_intro_articles') + $params->get(
-                    'num_links'
-                );
+            $limit = $params->get('num_leading_articles') + $params->get('num_intro_articles') + $params->get('num_links');
             $this->setState('list.links', $params->get('num_links'));
         } else {
             $limit = $app->getUserStateFromRequest(
@@ -294,7 +292,7 @@ class CategoryModel extends ListModel
         $query = $db->getQuery(true);
 
         $recursive  = false;
-        $options = ['countItems' => 1];
+        $options    = ['countItems' => 1];
         $categories = Categories::getInstance('Jed', $options);
 
         $this->_parent = $categories->get($this->getState('filter.parentId', 'root'));
@@ -423,10 +421,7 @@ class CategoryModel extends ListModel
             if (isset($this->state->params)) {
                 $params                = $this->state->params;
                 $options               = [];
-                $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get(
-                        'show_empty_categories_cat',
-                        0
-                    );
+                $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat',0);
                 $options['access']     = $params->get('check_access_rights', 1);
             } else {
                 $options['countItems'] = 0;

--- a/src/components/com_jed/src/Model/CategoryModel.php
+++ b/src/components/com_jed/src/Model/CategoryModel.php
@@ -421,7 +421,7 @@ class CategoryModel extends ListModel
             if (isset($this->state->params)) {
                 $params                = $this->state->params;
                 $options               = [];
-                $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat',0);
+                $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
                 $options['access']     = $params->get('check_access_rights', 1);
             } else {
                 $options['countItems'] = 0;

--- a/src/components/com_jed/src/Model/ReviewsModel.php
+++ b/src/components/com_jed/src/Model/ReviewsModel.php
@@ -72,11 +72,11 @@ class ReviewsModel extends ListModel
     }
 
 
-       /**
-        * Checks whether or not a user is manager or super user
-        *
-        * @return bool
-        */
+    /**
+    * Checks whether or not a user is manager or super user
+    *
+    * @return bool
+    */
     public function isAdminOrSuperUser()
     {
         try {

--- a/src/components/com_jed/src/Model/ReviewscommentsModel.php
+++ b/src/components/com_jed/src/Model/ReviewscommentsModel.php
@@ -56,11 +56,11 @@ class ReviewscommentsModel extends ListModel
     }
 
 
-       /**
-        * Checks whether or not a user is manager or super user
-        *
-        * @return bool
-        */
+    /**
+    * Checks whether or not a user is manager or super user
+    *
+    * @return bool
+    */
     public function isAdminOrSuperUser()
     {
         try {

--- a/src/components/com_jed/src/View/Category/HtmlView.php
+++ b/src/components/com_jed/src/View/Category/HtmlView.php
@@ -48,11 +48,13 @@ class HtmlView extends CategoryView
 
         $app = Factory::getApplication();
 
-/**        $this->state      = $this->get('State');
+        /*
+        $this->state   = $this->get('State');
         $this->items      = $this->get('Items');
         $this->pagination = $this->get('Pagination');
         $this->params     = $app->getParams();
-**/
+        */
+
         // Check for errors.
         if (count($errors = $this->get('Errors'))) {
             throw new Exception(implode("\n", $errors));

--- a/src/components/com_jed/tmpl/categories/default.php
+++ b/src/components/com_jed/tmpl/categories/default.php
@@ -30,9 +30,7 @@ HTMLHelper::_('bootstrap.tooltip');
         ?>
     <div class="container">
         <div class="row gx-5">
-            <?php
-            foreach ($this->items as $c) {
-            ?>
+            <?php foreach ($this->items as $c) : ?>
                 <div class="col-lg-4 mb-3 card jed-home-category">
                     <div class="card-header jed-home-item-view">
                         <span class="jed-home-category-icon fa fa-camera rounded-circle bg-warning p-2 text-white d-inline-block"></span>
@@ -58,7 +56,7 @@ HTMLHelper::_('bootstrap.tooltip');
                         </ul>
                     </div>
                 </div>
-            <?php } ?>
+            <?php endforeach; ?>
         </div>
     </div>
     <?php } ?>


### PR DESCRIPTION
### Summary of Changes
Replaces the depricated CMSObject with Registry in all Html views of the backend.

### Testing Instructions
Enter a view in the backend.

### Actual result BEFORE applying this Pull Request
PHP error:
Cannot assign Joomla\CMS\MVC\Model\State to property Jed\Component\Jed\Administrator\View\<ViewName>\HtmlView::$state of type Joomla\CMS\Object\CMSObject 

### Expected result AFTER applying this Pull Request
No PHP error anymore.