### PR TITLE
Build and similar small stuff

### DIFF
--- a/build-windows.bat
+++ b/build-windows.bat
@@ -1,5 +1,2 @@
 rem Building com_jed4
-clean-windows.bat
-build-windows-a.bat
-build-windows-b.bat
-build-windows-c.bat
+clean-windows.bat & build-windows-a.bat & build-windows-b.bat & build-windows-c.bat

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "cd src/administrator/components/com_jed && composer install"
+      "composer -d src/administrator/components/com_jed install"
+    ],
+    "post-update-cmd": [
+      "composer -d src/administrator/components/com_jed update"
     ]
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,5 @@ parameters:
   paths:
     - src
   scanDirectories:
-    - libraries
   ignoreErrors:
   reportUnmatchedIgnoredErrors: false

--- a/src/administrator/components/com_jed/composer.lock
+++ b/src/administrator/components/com_jed/composer.lock
@@ -78,5 +78,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
- non existant folder from phpstan scan removed
- chaining for single install bat: Still runs all files if one exits with error. (for example when a folder to be deleted doesn't exist)
- composer updates are now chained the same way it was already for install
- composer update was run once - updated the composer plugin version of the nested lockfile