### PR TITLE
Update to Category display to show pill counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Once you see 'Installation of the package was successful.'
 In Admin visit JED and view Tickets, Vulnerable Items, Categories and Extensions
 
 To get the Template:
-* Install Joomla 4 template from the templatework folder (jtemplate_4.0.9_jedcustom).
+* Install Joomla 4 template from the templatework/jtemplate_4.0.9_jed folder (jtemplate_4.0.9_jedcustom.zip).
+* Goto System / Site Template Styles and click on round circle under default for Joomla - Default template.
 
 **Instructions for Front end testing.**
 

--- a/src/components/com_jed/tmpl/categories/default.php
+++ b/src/components/com_jed/tmpl/categories/default.php
@@ -22,8 +22,9 @@ use Joomla\CMS\Router\Route;
  *
  * @var \Jed\Component\Jed\Site\View\Categories\HtmlView $this
 */
+
 $wa = $this->document->getWebAssetManager();
-/*$wa->useStyle('com_jed.newjed')
+$wa->useStyle('com_jed.t09_jed'); /*
     ->useScript('form.validate');*/
 HTMLHelper::_('bootstrap.tooltip');
 ?>
@@ -39,22 +40,22 @@ HTMLHelper::_('bootstrap.tooltip');
                 <div class="col-lg-4 mb-3 card jed-home-category">
                     <div class="card-header jed-home-item-view">
                         <span class="jed-home-category-icon fa fa-camera rounded-circle bg-warning p-2 text-white d-inline-block"></span>
-                        <h4 class="jed-home-category-title d-inline-block">
+                        <h4 class="jed-home-category-title d-inline-block category_list_jed">
                             <a href="<?php echo Route::_('index.php?option=com_jed&view=category&id=' . $c->id); ?>">
                                 <?php echo $c->title; ?>
                             </a>
                         </h4>
-                        <span class="badge rounded-pill float-end"><?php echo $c->numitems; ?></span>
+                        <span class="badge badge-info rounded-pill float-end"><?php echo $c->numitems; ?></span>
                     </div>
                     <div class="card-body">
                         <ul class="list-group list-group-flush">
                             <?php foreach ($c->children as $sc) {
                                 if ($sc->numitems > 0) { ?>
-                                    <li class="list-group-item">
+                                    <li class="list-group-item category_list_jed">
                                         <a href="<?php echo Route::_('index.php?option=com_jed&view=category&id=' . $sc->id); ?>">
                                             <?php echo $sc->title; ?>
                                         </a>
-                                        <span class="badge rounded-pill float-end badge-info-cat">  <?php echo $sc->numitems; ?></span>
+                                        <span class="badge rounded-pill float-end badge-info">  <?php echo $sc->numitems; ?></span>
                                     </li>
                                 <?php }
                             } ?>

--- a/src/media/com_jed/css/t09_jed.css
+++ b/src/media/com_jed/css/t09_jed.css
@@ -1,0 +1,9 @@
+/* CSS Styling for Com_JED when used with Joomla! Template 4.09 */
+.label-info,
+.badge-info {
+    background-color:#3a87ad
+}
+
+.category_list_jed a {
+    text-decoration: none;
+}

--- a/src/media/com_jed/joomla.asset.json
+++ b/src/media/com_jed/joomla.asset.json
@@ -17,6 +17,11 @@
       "uri": "media/com_jed/css/jedvel.css"
     },
     {
+      "name": "com_jed.t09_jed",
+      "type": "style",
+      "uri": "media/com_jed/css/t09_jed.css"
+    },
+    {
       "name": "com_jed.vulnerableItemBuildTitle",
       "type": "script",
       "uri": "media/com_jed/js/vulnerableItemBuildTitle.js",


### PR DESCRIPTION
### **User description**
Realised that Category counts were not displaying when using JTemplate as that overrites the pills from blue to white on white background!


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Added custom CSS to restore category pill counts visibility.

- Updated category template to use new CSS classes for pills.

- Registered new CSS asset in Joomla asset manifest.

- Clarified Joomla template installation instructions in README.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.php</strong><dd><code>Update category template to use custom pill styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/com_jed/tmpl/categories/default.php

<li>Applied new CSS class <code>category_list_jed</code> to category titles and items.<br> <li> Changed badge classes to use <code>badge-info</code> for improved visibility.<br> <li> Ensured category and subcategory pill counts display correctly.<br> <li> Enabled new stylesheet <code>com_jed.t09_jed</code> for the view.


</details>


  </td>
  <td><a href="https://github.com/joomla-projects/Joomla-Extension-Directory/pull/40/files#diff-034a1ede305c2010f66267d88fbd2cd635f41b38da6ec47c574596a4aa9a807f">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>t09_jed.css</strong><dd><code>Add custom CSS for category pill and link styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/media/com_jed/css/t09_jed.css

<li>Added new CSS file for custom category and badge styling.<br> <li> Defined <code>.badge-info</code> and <code>.category_list_jed a</code> styles for pill <br>visibility.


</details>


  </td>
  <td><a href="https://github.com/joomla-projects/Joomla-Extension-Directory/pull/40/files#diff-1570024b8b325c8e88572efa6ef98139080448a51f03a35ec85fc773dda54727">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>joomla.asset.json</strong><dd><code>Register new CSS asset for custom category styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/media/com_jed/joomla.asset.json

<li>Registered new CSS asset <code>com_jed.t09_jed</code> for use in the component.


</details>


  </td>
  <td><a href="https://github.com/joomla-projects/Joomla-Extension-Directory/pull/40/files#diff-65772e3daa26e306b3d1c18f65a56d183154308e1397a208b09ace9e2af1ed9e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with clearer template setup steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Clarified Joomla template installation and activation instructions.


</details>


  </td>
  <td><a href="https://github.com/joomla-projects/Joomla-Extension-Directory/pull/40/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>